### PR TITLE
Fix new layer in map

### DIFF
--- a/packages/base/src/mainview/mainview.tsx
+++ b/packages/base/src/mainview/mainview.tsx
@@ -373,7 +373,9 @@ export class MainView extends React.Component<IProps, IStates> {
       if (!layer) {
         this.removeLayer(change.id);
       } else {
-        if (JupyterGISModel.getOrderedLayerIds(this._model).includes(change.id)) {
+        if (
+          JupyterGISModel.getOrderedLayerIds(this._model).includes(change.id)
+        ) {
           this.updateLayer(change.id, layer);
         }
       }

--- a/packages/base/src/mainview/mainview.tsx
+++ b/packages/base/src/mainview/mainview.tsx
@@ -373,7 +373,9 @@ export class MainView extends React.Component<IProps, IStates> {
       if (!layer) {
         this.removeLayer(change.id);
       } else {
-        this.updateLayer(change.id, layer);
+        if (JupyterGISModel.getOrderedLayerIds(this._model).includes(change.id)) {
+          this.updateLayer(change.id, layer);
+        }
       }
     });
   }

--- a/packages/base/src/mainview/mainview.tsx
+++ b/packages/base/src/mainview/mainview.tsx
@@ -293,7 +293,7 @@ export class MainView extends React.Component<IProps, IStates> {
     const currentLayerIds = this._Map.getStyle().layers.map(layer => layer.id);
     let beforeId: string | undefined = undefined;
     if (!(index === undefined) && index < currentLayerIds.length) {
-      beforeId = currentLayerIds[index + 1];
+      beforeId = currentLayerIds[index];
     }
     this._Map.moveLayer(id, beforeId);
   }

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -332,7 +332,7 @@ export class JupyterGISModel implements IJupyterGISModel {
       this._sharedModel.updateLayerTreeItem(mainGroupIndex, mainGroup);
     } else {
       this.sharedModel.addLayerTreeItem(
-        index ?? this.getLayerTree.length,
+        index ?? this.getLayerTree().length,
         item
       );
     }


### PR DESCRIPTION
This PR fixes 3 issues when adding a layer in the tree:
- the layer position in the shared document, last if the position is not filled, instead of first currently
- correctly update the map with the new layer. This is fixed by not updating a layer which is not in map because of conflicts in MapLibre. 
- move the layer to its correct position in the Map after updating the layer tree