### PR TITLE
Add Context menu to layer tree items

### DIFF
--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -52,7 +52,7 @@ export namespace CommandIDs {
   export const removeGroup = 'jupytergis:removeGroup';
 
   export const moveLayersToGroup = 'jupytergis:moveLayersToGroup';
-  export const moveLayerToNewGroup = 'jupyterlab:moveLayerToNewGroup';
+  export const moveLayerToNewGroup = 'jupytergis:moveLayerToNewGroup';
 }
 
 /**
@@ -192,12 +192,14 @@ export function addCommands(
       function newGroupName() {
         const input = document.createElement('input');
         input.classList.add('jp-gis-left-panel-input');
-        const panel = document.getElementById('layertreepanel');
+        input.style.marginLeft = '26px';
+        const panel = document.getElementById('jp-gis-layer-tree');
         if (!panel) {
           return;
         }
 
         panel.appendChild(input);
+        input.focus();
 
         return new Promise<string>(resolve => {
           input.addEventListener('blur', () => {
@@ -221,6 +223,7 @@ export function addCommands(
 
       const newName = await newGroupName();
       if (!newName) {
+        console.warn('New name cannot be empty');
         return;
       }
 
@@ -648,7 +651,7 @@ namespace Private {
       originalName
     );
 
-    if (newName.trim() === '') {
+    if (!newName) {
       console.warn('New name cannot be empty');
       return;
     }

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -163,7 +163,8 @@ export function addCommands(
   });
 
   commands.addCommand(CommandIDs.moveLayersToGroup, {
-    label: args => args['label'] as string,
+    label: args =>
+      args['label'] ? (args['label'] as string) : trans.__('Move to Root'),
     execute: args => {
       const model = tracker.currentWidget?.context.model;
       const groupName = args['label'] as string;
@@ -179,7 +180,7 @@ export function addCommands(
   });
 
   commands.addCommand(CommandIDs.moveLayerToNewGroup, {
-    label: trans.__('Move layers to new group'),
+    label: trans.__('Move Layers to New Group'),
     execute: async () => {
       const model = tracker.currentWidget?.context.model;
       const selectedLayers = model?.localState?.selected?.value;
@@ -556,6 +557,8 @@ namespace Private {
   ): Promise<string> {
     const parent = text.parentElement as HTMLElement;
     parent.replaceChild(input, text);
+    input.value = original;
+    input.select();
     input.focus();
 
     return new Promise<string>(resolve => {

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -1,8 +1,3 @@
-import { JupyterFrontEnd } from '@jupyterlab/application';
-import { Dialog, WidgetTracker, showErrorMessage } from '@jupyterlab/apputils';
-import { PathExt } from '@jupyterlab/coreutils';
-import { ITranslator } from '@jupyterlab/translation';
-import { redoIcon, undoIcon } from '@jupyterlab/ui-components';
 import {
   IDict,
   IGeoJSONSource,
@@ -10,20 +5,26 @@ import {
   IJGISLayer,
   IJGISLayerBrowserRegistry,
   IJGISSource,
-  IJupyterGISModel
+  IJupyterGISModel,
+  SelectionType
 } from '@jupytergis/schema';
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { Dialog, WidgetTracker, showErrorMessage } from '@jupyterlab/apputils';
+import { PathExt } from '@jupyterlab/coreutils';
+import { ITranslator } from '@jupyterlab/translation';
+import { redoIcon, undoIcon } from '@jupyterlab/ui-components';
 import { UUID } from '@lumino/coreutils';
 import { Ajv } from 'ajv';
 import * as geojson from 'geojson-schema/GeoJSON.json';
 
+import { GeoJSONLayerDialog } from './dialogs/geoJsonLayerDialog';
+import { LayerBrowserWidget } from './dialogs/layerBrowserDialog';
 import {
   DataErrorDialog,
   DialogAddDataSourceBody,
   FormDialog
 } from './formdialog';
 import { geoJSONIcon } from './icons';
-import { LayerBrowserWidget } from './dialogs/layerBrowserDialog';
-import { GeoJSONLayerDialog } from './dialogs/geoJsonLayerDialog';
 import { JupyterGISWidget } from './widget';
 
 /**
@@ -41,6 +42,11 @@ export namespace CommandIDs {
   export const newVectorTileLayer = 'jupytergis:newVectorTileLayer';
 
   export const newVectorLayer = 'jupytergis:newVectorLayer';
+
+  export const renameLayer = 'jupytergis:renameLayer';
+  export const removeLayer = 'jupytergis:removeLayer';
+  export const renameGroup = 'jupytergis:renameGroup';
+  export const removeGroup = 'jupytergis:removeGroup';
 }
 
 /**
@@ -104,6 +110,74 @@ export function addCommands(
       layerBrowserRegistry,
       formSchemaRegistry
     )
+  });
+
+  commands.addCommand(CommandIDs.removeLayer, {
+    label: trans.__('Remove Layer'),
+    execute: () => {
+      const model = tracker.currentWidget?.context.model;
+      Private.removeSelectedItems(model, 'layer', selection => {
+        model?.sharedModel.removeLayer(selection);
+      });
+    }
+  });
+
+  commands.addCommand(CommandIDs.renameLayer, {
+    label: trans.__('Rename Layer'),
+    execute: async () => {
+      const model = tracker.currentWidget?.context.model;
+      await Private.renameSelectedItem(model, 'layer', (layerId, newName) => {
+        const layer = model?.getLayer(layerId);
+        if (layer) {
+          layer.name = newName;
+          model?.sharedModel.updateLayer(layerId, layer);
+        }
+      });
+    }
+  });
+
+  commands.addCommand(CommandIDs.removeGroup, {
+    label: trans.__('Remove Group'),
+    execute: async () => {
+      const model = tracker.currentWidget?.context.model;
+      Private.removeSelectedItems(model, 'group', selection => {
+        model?.removeLayerGroup(selection);
+      });
+    }
+  });
+
+  commands.addCommand(CommandIDs.renameGroup, {
+    label: trans.__('Rename Group'),
+    execute: async () => {
+      const model = tracker.currentWidget?.context.model;
+      await Private.renameSelectedItem(model, 'group', (groupName, newName) => {
+        model?.renameLayerGroup(groupName, newName);
+      });
+    }
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.removeLayer,
+    selector: '.jp-gis-layerTitle',
+    rank: 1
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.renameLayer,
+    selector: '.jp-gis-layerTitle',
+    rank: 1
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.removeGroup,
+    selector: '.jp-gis-layerGroupHeader',
+    rank: 1
+  });
+
+  app.contextMenu.addItem({
+    command: CommandIDs.renameGroup,
+    selector: '.jp-gis-layerGroupHeader',
+    rank: 1
   });
 
   commands.addCommand(CommandIDs.newGeoJSONLayer, {
@@ -415,5 +489,111 @@ namespace Private {
       });
       await dialog.launch();
     };
+  }
+
+  export async function getUserInputForRename(
+    text: HTMLElement,
+    input: HTMLInputElement,
+    original: string
+  ): Promise<string> {
+    const parent = text.parentElement as HTMLElement;
+    parent.replaceChild(input, text);
+    input.focus();
+
+    return new Promise<string>(resolve => {
+      input.addEventListener('blur', () => {
+        parent.replaceChild(text, input);
+        resolve(input.value);
+      });
+
+      input.addEventListener('keydown', (event: KeyboardEvent) => {
+        if (event.key === 'Enter') {
+          event.stopPropagation();
+          event.preventDefault();
+          input.blur();
+        } else if (event.key === 'Escape') {
+          event.stopPropagation();
+          event.preventDefault();
+          input.value = original;
+          input.blur();
+          text.focus();
+        }
+      });
+    });
+  }
+
+  export function removeSelectedItems(
+    model: IJupyterGISModel | undefined,
+    itemTypeToRemove: SelectionType,
+    removeFunction: (id: string) => void
+  ) {
+    const selected = model?.localState?.selected.value;
+
+    if (!selected) {
+      console.info('Nothing selected');
+      return;
+    }
+
+    for (const selection in selected) {
+      if (selected[selection].type === itemTypeToRemove) {
+        removeFunction(selection);
+      }
+    }
+  }
+
+  export async function renameSelectedItem(
+    model: IJupyterGISModel | undefined,
+    itemType: SelectionType,
+    callback: (itemId: string, newName: string) => void
+  ) {
+    const selectedItems = model?.localState?.selected.value;
+
+    if (!selectedItems) {
+      console.error(`No ${itemType} selected`);
+      return;
+    }
+
+    let itemId = '';
+
+    // If more then one item is selected, only rename the first
+    for (const id in selectedItems) {
+      if (selectedItems[id].type === itemType) {
+        itemId = id;
+        break;
+      }
+    }
+
+    if (!itemId) {
+      return;
+    }
+
+    const nodeId = selectedItems[itemId].selectedNodeId;
+    if (!nodeId) {
+      return;
+    }
+
+    const node = document.getElementById(nodeId);
+    if (!node) {
+      console.warn(`Node with ID ${nodeId} not found`);
+      return;
+    }
+
+    const edit = document.createElement('input');
+    edit.classList.add('jp-gis-left-panel-input');
+    const originalName = node.innerText;
+    const newName = await Private.getUserInputForRename(
+      node,
+      edit,
+      originalName
+    );
+
+    if (newName.trim() === '') {
+      console.warn('New name cannot be empty');
+      return;
+    }
+
+    if (newName !== originalName) {
+      callback(itemId, newName);
+    }
   }
 }

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -49,7 +49,7 @@ export namespace CommandIDs {
   export const renameGroup = 'jupytergis:renameGroup';
   export const removeGroup = 'jupytergis:removeGroup';
 
-  export const addLayersToGroup = 'jupytergis:addLayersToGroup';
+  export const moveLayersToGroup = 'jupytergis:moveLayersToGroup';
 }
 
 /**
@@ -159,9 +159,8 @@ export function addCommands(
     }
   });
 
-  commands.addCommand(CommandIDs.addLayersToGroup, {
+  commands.addCommand(CommandIDs.moveLayersToGroup, {
     label: args => args['label'] as string,
-    //TODO only enable when more than one selected
     execute: args => {
       const model = tracker.currentWidget?.context.model;
       console.log('first', model?.localState?.selected?.value);

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -48,6 +48,8 @@ export namespace CommandIDs {
   export const removeLayer = 'jupytergis:removeLayer';
   export const renameGroup = 'jupytergis:renameGroup';
   export const removeGroup = 'jupytergis:removeGroup';
+
+  export const addLayersToGroup = 'jupytergis:addLayersToGroup';
 }
 
 /**
@@ -154,6 +156,25 @@ export function addCommands(
       await Private.renameSelectedItem(model, 'group', (groupName, newName) => {
         model?.renameLayerGroup(groupName, newName);
       });
+    }
+  });
+
+  commands.addCommand(CommandIDs.addLayersToGroup, {
+    label: args => args['label'] as string,
+    //TODO only enable when more than one selected
+    execute: args => {
+      const model = tracker.currentWidget?.context.model;
+      console.log('first', model?.localState?.selected?.value);
+      console.log('args[]', args['label']);
+      const groupName = args['label'] as string;
+
+      const selectedLayers = model?.localState?.selected?.value;
+
+      if (!selectedLayers) {
+        return;
+      }
+
+      model.moveSelectedLayersToGroup(selectedLayers, groupName);
     }
   });
 

--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -31,6 +31,7 @@ import { JupyterGISWidget } from './widget';
  * The command IDs.
  */
 export namespace CommandIDs {
+  export const createNew = 'jupytergis:create-new-jGIS-file';
   export const redo = 'jupytergis:redo';
   export const undo = 'jupytergis:undo';
 
@@ -154,30 +155,6 @@ export function addCommands(
         model?.renameLayerGroup(groupName, newName);
       });
     }
-  });
-
-  app.contextMenu.addItem({
-    command: CommandIDs.removeLayer,
-    selector: '.jp-gis-layerTitle',
-    rank: 1
-  });
-
-  app.contextMenu.addItem({
-    command: CommandIDs.renameLayer,
-    selector: '.jp-gis-layerTitle',
-    rank: 1
-  });
-
-  app.contextMenu.addItem({
-    command: CommandIDs.removeGroup,
-    selector: '.jp-gis-layerGroupHeader',
-    rank: 1
-  });
-
-  app.contextMenu.addItem({
-    command: CommandIDs.renameGroup,
-    selector: '.jp-gis-layerGroupHeader',
-    rank: 1
   });
 
   commands.addCommand(CommandIDs.newGeoJSONLayer, {

--- a/packages/base/src/mainview/mainview.tsx
+++ b/packages/base/src/mainview/mainview.tsx
@@ -553,11 +553,10 @@ export class MainView extends React.Component<IProps, IStates> {
     }
     change.layerChange?.forEach(change => {
       const layer = change.newValue;
-      if (layer && Object.keys(layer).length === 0) {
+      if (!layer || Object.keys(layer).length === 0) {
         this.removeLayer(change.id);
       } else {
         if (
-          layer &&
           JupyterGISModel.getOrderedLayerIds(this._model).includes(change.id)
         ) {
           this.updateLayer(change.id, layer);

--- a/packages/base/src/mainview/mainview.tsx
+++ b/packages/base/src/mainview/mainview.tsx
@@ -553,10 +553,11 @@ export class MainView extends React.Component<IProps, IStates> {
     }
     change.layerChange?.forEach(change => {
       const layer = change.newValue;
-      if (!layer) {
+      if (layer && Object.keys(layer).length === 0) {
         this.removeLayer(change.id);
       } else {
         if (
+          layer &&
           JupyterGISModel.getOrderedLayerIds(this._model).includes(change.id)
         ) {
           this.updateLayer(change.id, layer);

--- a/packages/base/src/panelview/components/layers.tsx
+++ b/packages/base/src/panelview/components/layers.tsx
@@ -26,6 +26,7 @@ const LAYER_ITEM_CLASS = 'jp-gis-layerItem';
 const LAYER_CLASS = 'jp-gis-layer';
 const LAYER_TITLE_CLASS = 'jp-gis-layerTitle';
 const LAYER_ICON_CLASS = 'jp-gis-layerIcon';
+const LAYER_TEXT_CLASS = 'jp-gis-layerText';
 
 /**
  * The namespace for the layers panel.
@@ -262,7 +263,9 @@ function LayerGroupComponent(props: ILayerGroupProps): JSX.Element {
           }
           tag={'span'}
         />
-        <span id={id}>{name}</span>
+        <span id={id} className={LAYER_TEXT_CLASS}>
+          {name}
+        </span>
       </div>
       {open && (
         <div>
@@ -371,7 +374,9 @@ function LayerComponent(props: ILayerProps): JSX.Element {
             className={LAYER_ICON_CLASS}
           />
         )}
-        <span id={id}>{name}</span>
+        <span id={id} className={LAYER_TEXT_CLASS}>
+          {name}
+        </span>
       </div>
       <Button
         title={layer.visible ? 'Hide layer' : 'Show layer'}

--- a/packages/base/src/panelview/components/layers.tsx
+++ b/packages/base/src/panelview/components/layers.tsx
@@ -184,7 +184,6 @@ function LayerGroupComponent(props: ILayerGroupProps): JSX.Element {
 
   const handleRightClick = (event: MouseEvent<HTMLElement>) => {
     const childId = event.currentTarget.children.namedItem(id)?.id;
-    console.log('childId', childId);
     onClick('group', name, childId);
   };
 

--- a/packages/base/src/panelview/components/layers.tsx
+++ b/packages/base/src/panelview/components/layers.tsx
@@ -196,7 +196,7 @@ function LayersBodyComponent(props: IBodyProps): JSX.Element {
   });
 
   return (
-    <div id="layertreepanel">
+    <div id="jp-gis-layer-tree">
       {layerTree.map(layer =>
         typeof layer === 'string' ? (
           <LayerComponent

--- a/packages/base/src/panelview/components/layers.tsx
+++ b/packages/base/src/panelview/components/layers.tsx
@@ -196,7 +196,7 @@ function LayersBodyComponent(props: IBodyProps): JSX.Element {
   });
 
   return (
-    <div>
+    <div id="layertreepanel">
       {layerTree.map(layer =>
         typeof layer === 'string' ? (
           <LayerComponent

--- a/packages/base/style/leftPanel.css
+++ b/packages/base/style/leftPanel.css
@@ -87,3 +87,7 @@
 .jp-gis-layerText {
   padding: 3px 0;
 }
+
+li .lm-Menu-itemLabel {
+  text-transform: capitalize;
+}

--- a/packages/base/style/leftPanel.css
+++ b/packages/base/style/leftPanel.css
@@ -77,8 +77,13 @@
   flex-grow: 1;
   margin-right: 4px;
   outline: none;
+  padding: 2px 7px;
 }
 
 .jp-gis-left-panel-input:focus {
   border: 1px solid var(--jp-brand-color1);
+}
+
+.jp-gis-layerText {
+  padding: 3px 0;
 }

--- a/packages/base/style/leftPanel.css
+++ b/packages/base/style/leftPanel.css
@@ -68,3 +68,17 @@
 .jp-gis-layerTitle .jp-gis-layerIcon {
   padding-right: 4px;
 }
+
+.jp-gis-left-panel-input {
+  background-color: transparent;
+  border: 1px solid var(--jp-border-color1);
+  border-radius: 8px;
+  color: var(--jp-ui-font-color1);
+  flex-grow: 1;
+  margin-right: 4px;
+  outline: none;
+}
+
+.jp-gis-left-panel-input:focus {
+  border: 1px solid var(--jp-brand-color1);
+}

--- a/packages/schema/src/doc.ts
+++ b/packages/schema/src/doc.ts
@@ -157,7 +157,9 @@ export class JupyterGISDoc
   updateLayerTreeItem(index: number, item: IJGISLayerItem) {
     this.transact(() => {
       this._layerTree.delete(index);
-      this._layerTree.insert(index, [item]);
+      if (item) {
+        this._layerTree.insert(index, [item]);
+      }
     });
   }
 

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -162,6 +162,10 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
 
   removeLayerGroup(groupName: string): void;
   renameLayerGroup(groupName: string, newName: string): void;
+  moveSelectedLayersToGroup(
+    selected: { [key: string]: ISelection },
+    groupName: string
+  ): void;
 
   syncSelected(value: { [key: string]: ISelection }, emitter?: string): void;
   setUserToFollow(userId?: number): void;

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -17,6 +17,7 @@ import { GeoJSON } from './_interface/geojsonsource';
 import {
   IJGISContent,
   IJGISLayer,
+  IJGISLayerGroup,
   IJGISLayerItem,
   IJGISLayers,
   IJGISLayerTree,
@@ -165,6 +166,10 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
   moveSelectedLayersToGroup(
     selected: { [key: string]: ISelection },
     groupName: string
+  ): void;
+  addNewLayerGroup(
+    selected: { [key: string]: ISelection },
+    group: IJGISLayerGroup
   ): void;
 
   syncSelected(value: { [key: string]: ISelection }, emitter?: string): void;

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -13,6 +13,7 @@ import { User } from '@jupyterlab/services';
 import { ReactWidget } from '@jupyterlab/ui-components';
 import { ISignal, Signal } from '@lumino/signaling';
 
+import { GeoJSON } from './_interface/geojsonsource';
 import {
   IJGISContent,
   IJGISLayer,
@@ -24,7 +25,6 @@ import {
   IJGISSources
 } from './_interface/jgis';
 import { IRasterSource } from './_interface/rastersource';
-import { GeoJSON } from './_interface/geojsonsource';
 
 export { IGeoJSONSource } from './_interface/geojsonsource';
 
@@ -50,9 +50,12 @@ export interface IJGISSourceDocChange {
   }>;
 }
 
+export type SelectionType = 'layer' | 'source' | 'group';
+
 export interface ISelection {
-  type: 'layer' | 'source';
+  type: SelectionType;
   parent?: string;
+  selectedNodeId?: string;
 }
 
 export interface IJupyterGISClientState {
@@ -80,6 +83,7 @@ export interface IJupyterGISDoc extends YDocument<IJupyterGISDocChange> {
     groupName?: string,
     position?: number
   ): void;
+
   updateLayer(id: string, value: IJGISLayer): void;
 
   sourceExists(id: string): boolean;
@@ -155,6 +159,9 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
   setOptions(value: IJGISOptions): void;
 
   readGeoJSON(filepath: string): Promise<GeoJSON | undefined>;
+
+  removeLayerGroup(groupName: string): void;
+  renameLayerGroup(groupName: string, newName: string): void;
 
   syncSelected(value: { [key: string]: ISelection }, emitter?: string): void;
   setUserToFollow(userId?: number): void;

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -296,7 +296,7 @@ export class JupyterGISModel implements IJupyterGISModel {
    *
    * @param id - the ID of the layer.
    * @param layer - the layer object.
-   * @param groupName - optional) the name of the group in which to include the new
+   * @param groupName - (optional) the name of the group in which to include the new
    *   layer.
    * @param position - (optional) the index of the new layer in its parent group or
    *   from root of layer tree.
@@ -392,9 +392,9 @@ export class JupyterGISModel implements IJupyterGISModel {
   removeLayerGroup(groupName: string) {
     const layerTree = this.getLayerTree();
     const layerTreeInfo = this._getLayerTreeInfo(groupName);
-    const updatedLayerTree = removeLayerGroupItem(layerTree, groupName);
+    const updatedLayerTree = removeLayerGroupEntry(layerTree, groupName);
 
-    function removeLayerGroupItem(
+    function removeLayerGroupEntry(
       layerTree: IJGISLayerItem[],
       groupName: string
     ): IJGISLayerItem[] {
@@ -404,7 +404,7 @@ export class JupyterGISModel implements IJupyterGISModel {
         if (typeof item === 'string') {
           result.push(item); // Push layer IDs directly
         } else if (item.name !== groupName) {
-          const filteredLayers = removeLayerGroupItem(item.layers, groupName);
+          const filteredLayers = removeLayerGroupEntry(item.layers, groupName);
           result.push({ ...item, layers: filteredLayers }); // Update layers with filtered list
         }
       }

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -308,7 +308,6 @@ export class JupyterGISModel implements IJupyterGISModel {
     position?: number
   ): void {
     if (!this.getLayer(id)) {
-      console.log('does this happen');
       this.sharedModel.addLayer(id, layer);
     }
 
@@ -355,40 +354,26 @@ export class JupyterGISModel implements IJupyterGISModel {
     index?: number
   ): void {
     if (groupName) {
-      console.log('adding', item);
       const layerTreeInfo = this._getLayerTreeInfo(groupName);
 
       if (layerTreeInfo) {
-        console.log('still adding');
-        console.log(
-          'dev 1',
-          JSON.parse(JSON.stringify(layerTreeInfo.workingGroup.layers))
-        );
-
         layerTreeInfo.workingGroup.layers.splice(
           index ?? layerTreeInfo.workingGroup.layers.length,
           0,
           item
         );
 
-        console.log(
-          'dev 2',
-          JSON.parse(JSON.stringify(layerTreeInfo.workingGroup.layers))
-        );
         this._sharedModel.updateLayerTreeItem(
           layerTreeInfo.mainGroupIndex,
           layerTreeInfo.mainGroup
         );
       }
     } else {
-      console.log('sanity -- shouldnt happen');
       this.sharedModel.addLayerTreeItem(
         index ?? this.getLayerTree().length,
         item
       );
     }
-
-    console.log('layer tree in add', this.sharedModel.layerTree);
   }
 
   moveSelectedLayersToGroup(
@@ -397,48 +382,34 @@ export class JupyterGISModel implements IJupyterGISModel {
   ) {
     const layerTree = this.getLayerTree();
     for (const item in selected) {
-      console.log('item in first function', item);
       this._removeLayerTreeLayer(layerTree, item);
-
-      // this._addLayerTreeItem(item, groupName);
     }
 
     for (const item in selected) {
-      console.log('item in first function', item);
-      // this._removeLayerTreeLayer(layerTree, item);
-
       this._addLayerTreeItem(item, groupName);
     }
-
-    // console.log('this.getLayers()', this.getLayers());
   }
 
   private _removeLayerTreeLayer(
     layerTree: IJGISLayerTree,
-    targetString: string
+    layerIdToRemove: string
   ) {
-    // const layerTree = this.getLayerTree();
-
     // Iterate over each item in the layerTree
     for (let i = 0; i < layerTree.length; i++) {
       const currentItem = layerTree[i];
-      console.log('currentItem', currentItem);
 
       // Check if the current item is a string and matches the target
-      if (typeof currentItem === 'string' && currentItem === targetString) {
+      if (typeof currentItem === 'string' && currentItem === layerIdToRemove) {
         // Remove the item from the array
-        console.log('removing', currentItem);
         layerTree.splice(i, 1);
         // Decrement i to ensure the next iteration processes the remaining items correctly
         i--;
       } else if (typeof currentItem !== 'string' && 'layers' in currentItem) {
-        console.log('elseing');
         // If the current item is a group, recursively call the function on its layers
-        this._removeLayerTreeLayer(currentItem.layers, targetString);
+        this._removeLayerTreeLayer(currentItem.layers, layerIdToRemove);
       }
     }
 
-    // console.log('layerTree in remove', layerTree);
     this.sharedModel.layerTree = layerTree;
   }
 
@@ -495,7 +466,6 @@ export class JupyterGISModel implements IJupyterGISModel {
       }
     | undefined {
     const layerTree = this.getLayerTree();
-    console.log('dev in info', JSON.parse(JSON.stringify(layerTree)));
     const indexesPath = Private.findGroupPath(layerTree, groupName);
     if (!indexesPath.length) {
       console.warn(`The group "${groupName}" does not exist in the layer tree`);

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -390,6 +390,18 @@ export class JupyterGISModel implements IJupyterGISModel {
     }
   }
 
+  addNewLayerGroup(
+    selected: { [key: string]: ISelection },
+    group: IJGISLayerGroup
+  ) {
+    const layerTree = this.getLayerTree();
+    for (const item in selected) {
+      this._removeLayerTreeLayer(layerTree, item);
+    }
+
+    this._addLayerTreeItem(group);
+  }
+
   private _removeLayerTreeLayer(
     layerTree: IJGISLayerTree,
     layerIdToRemove: string

--- a/python/jupytergis_core/src/jgisplugin/plugins.ts
+++ b/python/jupytergis_core/src/jgisplugin/plugins.ts
@@ -24,13 +24,14 @@ import { fileIcon } from '@jupyterlab/ui-components';
 
 import { JupyterGISWidgetFactory } from '../factory';
 import { JupyterGISModelFactory } from './modelfactory';
+import { CommandIDs } from '@jupytergis/base';
 
 const FACTORY = 'JupyterGIS .jgis Viewer';
 const PALETTE_CATEGORY = 'JupyterGIS';
 
-namespace CommandIDs {
-  export const createNew = 'jupytergis:create-new-jGIS-file';
-}
+// namespace CommandIDs {
+//   export const createNew = 'jupytergis:create-new-jGIS-file';
+// }
 
 const activate = (
   app: JupyterFrontEnd,
@@ -138,6 +139,25 @@ const activate = (
       command: CommandIDs.createNew,
       args: { isPalette: true },
       category: PALETTE_CATEGORY
+    });
+    palette.addItem({
+      command: CommandIDs.removeLayer,
+      category: 'Other'
+    });
+
+    palette.addItem({
+      command: CommandIDs.renameLayer,
+      category: 'Other'
+    });
+
+    palette.addItem({
+      command: CommandIDs.removeGroup,
+      category: 'Other'
+    });
+
+    palette.addItem({
+      command: CommandIDs.renameGroup,
+      category: 'Other'
     });
   }
 };

--- a/python/jupytergis_core/src/jgisplugin/plugins.ts
+++ b/python/jupytergis_core/src/jgisplugin/plugins.ts
@@ -22,16 +22,12 @@ import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { ILauncher } from '@jupyterlab/launcher';
 import { fileIcon } from '@jupyterlab/ui-components';
 
+import { CommandIDs } from '@jupytergis/base';
 import { JupyterGISWidgetFactory } from '../factory';
 import { JupyterGISModelFactory } from './modelfactory';
-import { CommandIDs } from '@jupytergis/base';
 
 const FACTORY = 'JupyterGIS .jgis Viewer';
 const PALETTE_CATEGORY = 'JupyterGIS';
-
-// namespace CommandIDs {
-//   export const createNew = 'jupytergis:create-new-jGIS-file';
-// }
 
 const activate = (
   app: JupyterFrontEnd,

--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -234,6 +234,10 @@ function buildGroupsMenu(
       args: { label: name }
     });
   });
+
+  submenu.addItem({
+    command: CommandIDs.moveLayerToNewGroup
+  });
 }
 
 export default [plugin, controlPanel, notebookRenderePlugin];

--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -12,6 +12,7 @@ import {
   IJGISFormSchemaRegistryToken,
   IJGISLayerBrowserRegistry,
   IJGISLayerBrowserRegistryToken,
+  IJGISLayerItem,
   IJupyterGISDocTracker,
   IJupyterGISTracker
 } from '@jupytergis/schema';
@@ -24,6 +25,7 @@ import { WidgetTracker } from '@jupyterlab/apputils';
 import { IMainMenu } from '@jupyterlab/mainmenu';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
 
+import { ContextMenu, Menu } from '@lumino/widgets';
 import { notebookRenderePlugin } from './notebookrenderer';
 
 const NAME_SPACE = 'jupytergis';
@@ -76,6 +78,26 @@ const plugin: JupyterFrontEndPlugin<void> = {
       rank: 1
     });
 
+    const submenu = new Menu({ commands: app.commands });
+    submenu.title.label = translator
+      .load('jupyterlab')
+      .__('Move layers to group');
+
+    app.contextMenu.addItem({
+      type: 'submenu',
+      selector: '.jp-gis-layerTitle',
+      rank: 2,
+      submenu
+    });
+
+    app.contextMenu.opened.connect(() => groupsMenu(app.contextMenu, tracker));
+
+    app.contextMenu.addItem({
+      type: 'separator',
+      selector: '.jp-gis-layerGroupHeader',
+      rank: 1
+    });
+
     app.contextMenu.addItem({
       command: CommandIDs.removeGroup,
       selector: '.jp-gis-layerGroupHeader',
@@ -92,6 +114,62 @@ const plugin: JupyterFrontEndPlugin<void> = {
       populateMenus(mainMenu, isEnabled);
     }
   }
+};
+
+const groupsMenu = (
+  contextMenu: ContextMenu,
+  tracker: WidgetTracker<JupyterGISWidget>
+) => {
+  if (!tracker.currentWidget?.context.model) {
+    return;
+  }
+
+  const model = tracker.currentWidget?.context.model;
+
+  const submenu =
+    contextMenu.menu.items.find(item => item.type === 'submenu')?.submenu ??
+    null;
+
+  // Bail early if the submenu isn't found
+  if (!submenu) {
+    return;
+  }
+
+  submenu.clearItems();
+
+  // need a list of group name
+  const layerTree = model.getLayerTree();
+  const groupNames = getLayerGroupNames(layerTree);
+
+  function getLayerGroupNames(layerTree: IJGISLayerItem[]): string[] {
+    const result: string[] = [];
+
+    for (const item of layerTree) {
+      // Skip if the item is a layer id
+      if (typeof item === 'string') {
+        continue;
+      }
+
+      // Process group items
+      if (item.layers) {
+        result.push(item.name);
+
+        // Recursively process the layers of the current item
+        const nestedResults = getLayerGroupNames(item.layers);
+        // Append the results of the recursive call to the main result array
+        result.push(...nestedResults);
+      }
+    }
+
+    return result;
+  }
+
+  groupNames.forEach(name => {
+    submenu.addItem({
+      command: CommandIDs.moveLayersToGroup,
+      args: { label: name }
+    });
+  });
 };
 
 const controlPanel: JupyterFrontEndPlugin<void> = {

--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -64,6 +64,30 @@ const plugin: JupyterFrontEndPlugin<void> = {
       layerBrowserRegistry
     );
 
+    app.contextMenu.addItem({
+      command: CommandIDs.removeLayer,
+      selector: '.jp-gis-layerTitle',
+      rank: 1
+    });
+
+    app.contextMenu.addItem({
+      command: CommandIDs.renameLayer,
+      selector: '.jp-gis-layerTitle',
+      rank: 1
+    });
+
+    app.contextMenu.addItem({
+      command: CommandIDs.removeGroup,
+      selector: '.jp-gis-layerGroupHeader',
+      rank: 1
+    });
+
+    app.contextMenu.addItem({
+      command: CommandIDs.renameGroup,
+      selector: '.jp-gis-layerGroupHeader',
+      rank: 1
+    });
+
     if (mainMenu) {
       populateMenus(mainMenu, isEnabled);
     }

--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -81,7 +81,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     const submenu = new Menu({ commands: app.commands });
     submenu.title.label = translator
       .load('jupyterlab')
-      .__('Move layers to group');
+      .__('Move Layers to Group');
 
     app.contextMenu.addItem({
       type: 'submenu',
@@ -227,6 +227,11 @@ function buildGroupsMenu(
 
     return result;
   }
+
+  submenu.addItem({
+    command: CommandIDs.moveLayersToGroup,
+    args: { label: '' }
+  });
 
   groupNames.forEach(name => {
     submenu.addItem({


### PR DESCRIPTION
Add context menu to layer tree items

- [x] Remove layer
- [x] Rename layer
- [x] Remove group
- [x] Rename group
- [x] Add selected layers to group (Will need to be able to select multiple items for this) 
- [x] Make the input boxes when renaming look nicer

![context_menu_2](https://github.com/user-attachments/assets/deca6823-e26f-4933-bc1b-6db1ceb663c3)
