### PR TITLE
Update minZoom value for buildings example

### DIFF
--- a/examples/buildings.jGIS
+++ b/examples/buildings.jGIS
@@ -1,56 +1,57 @@
 {
+  "layerTree": [
+    "f99eb7b0-5e38-4078-b310-36a0746472aa",
+    "148f2fb3-3077-4dcb-8d70-831570d5021f"
+  ],
   "layers": {
     "148f2fb3-3077-4dcb-8d70-831570d5021f": {
-      "type": "VectorLayer",
       "name": "Vector Tile Source Layer",
       "parameters": {
+        "color": "#086600",
         "opacity": 1.0,
         "source": "7a7ee6fd-c1e2-4c5d-a4e2-a7974db138a4",
         "sourceLayer": "bingmlbuildings",
-        "color": "green",
         "type": "fill"
       },
+      "type": "VectorLayer",
       "visible": true
     },
     "f99eb7b0-5e38-4078-b310-36a0746472aa": {
+      "name": "OpenStreetMap.Mapnik Layer",
       "parameters": {
         "source": "ed8628b0-3e0a-45d5-9cd0-65e2a7dd61f5"
       },
-      "visible": true,
       "type": "RasterLayer",
-      "name": "OpenStreetMap.Mapnik Layer"
+      "visible": true
     }
+  },
+  "options": {
+    "latitude": 41.86704023051254,
+    "longitude": -87.64128426232207,
+    "zoom": 8.089610803710057
   },
   "sources": {
     "7a7ee6fd-c1e2-4c5d-a4e2-a7974db138a4": {
       "name": "Vector Tile Source",
       "parameters": {
-        "minZoom": 13.0,
+        "maxZoom": 13.0,
+        "minZoom": 0.0,
         "url": "https://planetarycomputer.microsoft.com/api/data/v1/vector/collections/ms-buildings/tilesets/global-footprints/tiles/{z}/{x}/{y}",
-        "maxZoom": 13.0
+        "urlParameters": {}
       },
       "type": "VectorTileSource"
     },
     "ed8628b0-3e0a-45d5-9cd0-65e2a7dd61f5": {
+      "name": "OpenStreetMap.Mapnik",
       "parameters": {
+        "attribution": "(C) OpenStreetMap contributors",
+        "maxZoom": 19.0,
+        "minZoom": 0.0,
         "provider": "OpenStreetMap",
         "url": "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
-        "maxZoom": 19.0,
-        "attribution": "(C) OpenStreetMap contributors",
-        "minZoom": 0.0,
         "urlParameters": {}
       },
-      "type": "RasterSource",
-      "name": "OpenStreetMap.Mapnik"
+      "type": "RasterSource"
     }
-  },
-  "options": {
-    "longitude": -88.1392955068439,
-    "zoom": 13.915138763623208,
-    "latitude": 41.932061631424034
-  },
-  "layerTree": [
-    "f99eb7b0-5e38-4078-b310-36a0746472aa",
-    "148f2fb3-3077-4dcb-8d70-831570d5021f"
-  ]
+  }
 }


### PR DESCRIPTION
It looks nicer that way, we can still unzoom and see the buildings

![Screenshot from 2024-07-16 11-06-51](https://github.com/user-attachments/assets/f7e1ef92-5818-48d1-9cd9-9dfbb86e25b2)
