### PR TITLE
Fix a typo on the layer tree observer

### DIFF
--- a/python/jupytergis_core/jupytergis_core/jgis_ydoc.py
+++ b/python/jupytergis_core/jupytergis_core/jgis_ydoc.py
@@ -68,6 +68,6 @@ class YJGIS(YBaseDoc):
         self._subscriptions[self._yoptions] = self._yoptions.observe_deep(
             partial(callback, "options")
         )
-        self._subscriptions[self._ylayerTree] = self._yoptions.observe(
+        self._subscriptions[self._ylayerTree] = self._ylayerTree.observe(
             partial(callback, "layerTree")
         )


### PR DESCRIPTION
This PR fix the layer tree observer on python side.

Before this PR, modifying the layer tree client side had no impact on the document server side.

Related to https://github.com/QuantStack/jupytergis/pull/48#issuecomment-2231396521