### PR TITLE
Disable form validation at startup if it is invalid

### DIFF
--- a/packages/base/src/formbuilder/creationform.tsx
+++ b/packages/base/src/formbuilder/creationform.tsx
@@ -61,6 +61,11 @@ export interface ICreationFormProps {
 
   formSchemaRegistry: IJGISFormSchemaRegistry;
   context: DocumentRegistry.IContext<IJupyterGISModel>;
+
+  /**
+   * A signal emitting when the form changed.
+   */
+  formChangedSignal?: Signal<Dialog<any>, void>;
 }
 
 /**
@@ -192,6 +197,7 @@ export class CreationForm extends React.Component<ICreationFormProps, any> {
               }}
               ok={this.props.ok}
               cancel={this.props.cancel}
+              formChangedSignal={this.props.formChangedSignal}
             />
           </div>
         )}
@@ -210,6 +216,7 @@ export class CreationForm extends React.Component<ICreationFormProps, any> {
               }}
               ok={this.props.ok}
               cancel={this.props.cancel}
+              formChangedSignal={this.props.formChangedSignal}
             />
           </div>
         )}

--- a/packages/base/src/formbuilder/creationform.tsx
+++ b/packages/base/src/formbuilder/creationform.tsx
@@ -63,9 +63,10 @@ export interface ICreationFormProps {
   context: DocumentRegistry.IContext<IJupyterGISModel>;
 
   /**
-   * A signal emitting when the form changed.
+   * A signal emitting when the form changed, with a boolean whether there are some
+   * extra errors or not.
    */
-  formChangedSignal?: Signal<Dialog<any>, void>;
+  formChangedSignal?: Signal<Dialog<any>, boolean>;
 }
 
 /**

--- a/packages/base/src/formbuilder/objectform/baseform.tsx
+++ b/packages/base/src/formbuilder/objectform/baseform.tsx
@@ -58,9 +58,10 @@ export interface IBaseFormProps {
   cancel?: () => void;
 
   /**
-   * The signal emitting when the form changed.
+   * A signal emitting when the form changed, with a boolean whether there are some
+   * extra errors or not.
    */
-  formChangedSignal?: Signal<Dialog<any>, void>;
+  formChangedSignal?: Signal<Dialog<any>, boolean>;
 }
 
 // Reusing the datalayer/jupyter-react component:
@@ -102,7 +103,8 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
     super(props);
     this.currentFormData = deepCopy(this.props.sourceData);
     this.state = {
-      schema: props.schema
+      schema: props.schema,
+      extraErrors: {}
     };
   }
 
@@ -205,11 +207,13 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
   }
 
   protected onFormChange(e: IChangeEvent) {
-    // Emit the signal if defined.
-    if (this.props.formChangedSignal){
-      this.props.formChangedSignal.emit();
-    }
     this.currentFormData = e.formData;
+
+    // Emit the signal if defined.
+    if (this.props.formChangedSignal) {
+      const extraErrors = Object.keys(this.state.extraErrors).length > 0;
+      this.props.formChangedSignal.emit(extraErrors);
+    }
   }
 
   protected onFormBlur(id: string, value: any) {

--- a/packages/base/src/formbuilder/objectform/baseform.tsx
+++ b/packages/base/src/formbuilder/objectform/baseform.tsx
@@ -56,6 +56,11 @@ export interface IBaseFormProps {
    * Cancel callback
    */
   cancel?: () => void;
+
+  /**
+   * The signal emitting when the form changed.
+   */
+  formChangedSignal?: Signal<Dialog<any>, void>;
 }
 
 // Reusing the datalayer/jupyter-react component:
@@ -200,6 +205,10 @@ export class BaseForm extends React.Component<IBaseFormProps, IBaseFormStates> {
   }
 
   protected onFormChange(e: IChangeEvent) {
+    // Emit the signal if defined.
+    if (this.props.formChangedSignal){
+      this.props.formChangedSignal.emit();
+    }
     this.currentFormData = e.formData;
   }
 

--- a/ui-tests/tests/geojson-layers.spec.ts
+++ b/ui-tests/tests/geojson-layers.spec.ts
@@ -60,6 +60,7 @@ test.describe('#geoJSONLayer', () => {
 
     const fileInput = dialog.getByLabel('path');
     await fileInput.fill('france_regions.json');
+    await fileInput.blur();
 
     const typeInput = dialog.getByLabel('type');
     typeInput.selectOption('line');

--- a/ui-tests/tests/left-panel.spec.ts
+++ b/ui-tests/tests/left-panel.spec.ts
@@ -329,6 +329,7 @@ test.describe('#sourcePanel', () => {
         const dialog = page.locator('.jGIS-layer-CreationFormDialog');
         await expect(dialog).toBeVisible();
         await dialog.getByRole('textbox').last().fill('france_regions.json');
+        await dialog.getByRole('textbox').last().blur();
         await dialog.locator('button.jp-mod-accept').click();
 
         // Expect the new source to be added and unused.


### PR DESCRIPTION
Fixes https://github.com/QuantStack/jupytergis/issues/69

- when the form is displayed the first time, do not disable the `OK` button if the form is valid.
- disable the `OK` button if there are extra errors from custom validation.