### PR TITLE
Reverse the layer order in side panel

### DIFF
--- a/packages/base/src/panelview/components/layers.tsx
+++ b/packages/base/src/panelview/components/layers.tsx
@@ -119,21 +119,23 @@ function LayersBodyComponent(props: IBodyProps): JSX.Element {
 
   return (
     <div id="jp-gis-layer-tree">
-      {layerTree.reverse().map(layer =>
-        typeof layer === 'string' ? (
-          <LayerComponent
-            gisModel={model}
-            layerId={layer}
-            onClick={onItemClick}
-          />
-        ) : (
-          <LayerGroupComponent
-            gisModel={model}
-            group={layer}
-            onClick={onItemClick}
-          />
-        )
-      )}
+      {layerTree
+        .reverse()
+        .map(layer =>
+          typeof layer === 'string' ? (
+            <LayerComponent
+              gisModel={model}
+              layerId={layer}
+              onClick={onItemClick}
+            />
+          ) : (
+            <LayerGroupComponent
+              gisModel={model}
+              group={layer}
+              onClick={onItemClick}
+            />
+          )
+        )}
     </div>
   );
 }
@@ -210,21 +212,23 @@ function LayerGroupComponent(props: ILayerGroupProps): JSX.Element {
       </div>
       {open && (
         <div>
-          {layers.reverse().map(layer =>
-            typeof layer === 'string' ? (
-              <LayerComponent
-                gisModel={gisModel}
-                layerId={layer}
-                onClick={onClick}
-              />
-            ) : (
-              <LayerGroupComponent
-                gisModel={gisModel}
-                group={layer}
-                onClick={onClick}
-              />
-            )
-          )}
+          {layers
+            .reverse()
+            .map(layer =>
+              typeof layer === 'string' ? (
+                <LayerComponent
+                  gisModel={gisModel}
+                  layerId={layer}
+                  onClick={onClick}
+                />
+              ) : (
+                <LayerGroupComponent
+                  gisModel={gisModel}
+                  group={layer}
+                  onClick={onClick}
+                />
+              )
+            )}
         </div>
       )}
     </div>

--- a/packages/base/src/panelview/components/layers.tsx
+++ b/packages/base/src/panelview/components/layers.tsx
@@ -119,7 +119,7 @@ function LayersBodyComponent(props: IBodyProps): JSX.Element {
 
   return (
     <div id="jp-gis-layer-tree">
-      {layerTree.map(layer =>
+      {layerTree.reverse().map(layer =>
         typeof layer === 'string' ? (
           <LayerComponent
             gisModel={model}
@@ -210,7 +210,7 @@ function LayerGroupComponent(props: ILayerGroupProps): JSX.Element {
       </div>
       {open && (
         <div>
-          {layers.map(layer =>
+          {layers.reverse().map(layer =>
             typeof layer === 'string' ? (
               <LayerComponent
                 gisModel={gisModel}

--- a/ui-tests/tests/contextmenu.spec.ts
+++ b/ui-tests/tests/contextmenu.spec.ts
@@ -202,7 +202,7 @@ test.describe('context menu', () => {
     await page.getByText('level 1 group').click();
     await page.getByText('level 2 group').click();
 
-    const group = page.getByText('level 2 groupRegions FranceOpen Topo Map');
+    const group = page.getByText('level 2 groupOpen Topo MapRegions France');
 
     await expect(group).toHaveCount(1);
   });

--- a/ui-tests/tests/left-panel.spec.ts
+++ b/ui-tests/tests/left-panel.spec.ts
@@ -104,17 +104,18 @@ test.describe('#layerPanel', () => {
     test('should navigate in nested groups', async ({ page }) => {
       const layerTree = await openLayerTree(page);
       const layerEntries = layerTree.locator('.jp-gis-layerItem');
+      const layerGroups = layerTree.locator('.jp-gis-layerGroup');
 
       await expect(layerEntries).toHaveCount(2);
-      await expect(layerEntries.first()).toHaveClass(/jp-gis-layer/);
-      await expect(layerEntries.last()).toHaveClass(/jp-gis-layerGroup/);
+      await expect(layerEntries.first()).toHaveClass(/jp-gis-layerGroup/);
+      await expect(layerEntries.last()).toHaveClass(/jp-gis-layer/);
 
       // Open the first level group
-      await layerEntries.last().click();
+      await layerGroups.first().click();
       await expect(layerEntries).toHaveCount(4);
 
       // Open the second level group
-      await layerEntries.last().click();
+      await layerGroups.last().click();
       await expect(layerEntries).toHaveCount(5);
     });
 
@@ -171,7 +172,7 @@ test.describe('#layerPanel', () => {
       const hideLayerButton = layerTree.getByTitle('Hide layer');
 
       // Hide the last layer (top in z-index).
-      await hideLayerButton.last().click();
+      await hideLayerButton.first().click();
       // wait for a significant change in the screenshots (1%).
       await page.waitForCondition(async () => {
         try {


### PR DESCRIPTION
Set the top layer on top of the list of layers in the tree layer side panel, like in QGIS.
