### PR TITLE
Drag and drop layers

### DIFF
--- a/packages/base/src/commands.ts
+++ b/packages/base/src/commands.ts
@@ -567,7 +567,7 @@ export function addCommands(
         return;
       }
 
-      model.moveSelectedLayersToGroup(selectedLayers, groupName);
+      model.moveItemsToGroup(Object.keys(selectedLayers), groupName);
     }
   });
 

--- a/packages/base/src/panelview/components/layers.tsx
+++ b/packages/base/src/panelview/components/layers.tsx
@@ -63,7 +63,7 @@ export class LayersPanel extends Panel {
     this.node.appendChild(Private.dragIndicator);
     Private.dragInfo.dragOverElement = null;
     Private.dragInfo.dragOverPosition = null;
-  }
+  };
 
   private _onDrop = (e: DragEvent) => {
     Private.dragIndicator.style.display = 'none';
@@ -71,9 +71,10 @@ export class LayersPanel extends Panel {
     if (this._model === undefined) {
       return;
     }
-    const {jGISModel: model} = this._model;
+    const { jGISModel: model } = this._model;
 
-    const {draggedElement, dragOverElement, dragOverPosition} = Private.dragInfo;
+    const { draggedElement, dragOverElement, dragOverPosition } =
+      Private.dragInfo;
 
     if (dragOverElement === 'error') {
       return;
@@ -105,10 +106,14 @@ export class LayersPanel extends Panel {
       dragOverPosition === 'below'
     ) {
       model?.moveItemsToGroup([draggedId], dragOverId);
-      return
+      return;
     }
 
-    model?.moveItemRelatedTo(draggedId, dragOverId, dragOverPosition === 'above');
+    model?.moveItemRelatedTo(
+      draggedId,
+      dragOverId,
+      dragOverPosition === 'above'
+    );
   };
 
   private _model: IControlPanelModel | undefined;
@@ -411,7 +416,6 @@ function LayerComponent(props: ILayerProps): JSX.Element {
 }
 
 namespace Private {
-
   export const dragIndicator = document.createElement('div');
   dragIndicator.id = 'jp-drag-indicator';
 
@@ -425,16 +429,16 @@ namespace Private {
     draggedElement: null,
     dragOverElement: null,
     dragOverPosition: null
-  }
+  };
 
   export const onDragStart = (e: React.DragEvent) => {
     dragInfo.draggedElement = e.target as HTMLDivElement;
-  }
+  };
 
   export const onDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    const {clientY} = e;
+    const { clientY } = e;
 
     let target = (e.target as HTMLElement).closest(
       `.${LAYER_GROUP_HEADER_CLASS}, .${LAYER_ITEM_CLASS}`
@@ -464,12 +468,12 @@ namespace Private {
       target.insertAdjacentElement('afterend', dragIndicator);
       dragIndicator.style.display = 'block';
     }
-  }
+  };
 
   export const onDragEnd = () => {
     dragIndicator.style.display = 'none';
     dragInfo.draggedElement = null;
     dragInfo.dragOverElement = null;
     dragInfo.dragOverPosition = null;
-  }
+  };
 }

--- a/packages/base/style/leftPanel.css
+++ b/packages/base/style/leftPanel.css
@@ -125,3 +125,12 @@ li .lm-Menu-itemLabel {
   padding-left: 5px;
   color: var(--jp-ui-font-color2);
 }
+
+#jp-drag-indicator {
+  top: calc(-1 * var(--jp-border-width) + 1px);
+  left: calc(-1 * var(--jp-border-width));
+  content: '';
+  height: var(--jp-private-horizontal-tab-active-top-border);
+  width: calc(100% + 2 * var(--jp-border-width));
+  background: var(--jp-brand-color1);
+}

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -171,10 +171,12 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
 
   removeLayerGroup(groupName: string): void;
   renameLayerGroup(groupName: string, newName: string): void;
-  moveSelectedLayersToGroup(
-    selected: { [key: string]: ISelection },
-    groupName: string
+  moveItemsToGroup(
+    items: string[],
+    groupName: string,
+    index?: number
   ): void;
+  moveItemRelatedTo(item: string, relativeItem: string, after: boolean): void;
   addNewLayerGroup(
     selected: { [key: string]: ISelection },
     group: IJGISLayerGroup

--- a/packages/schema/src/interfaces.ts
+++ b/packages/schema/src/interfaces.ts
@@ -171,11 +171,7 @@ export interface IJupyterGISModel extends DocumentRegistry.IModel {
 
   removeLayerGroup(groupName: string): void;
   renameLayerGroup(groupName: string, newName: string): void;
-  moveItemsToGroup(
-    items: string[],
-    groupName: string,
-    index?: number
-  ): void;
+  moveItemsToGroup(items: string[], groupName: string, index?: number): void;
   moveItemRelatedTo(item: string, relativeItem: string, after: boolean): void;
   addNewLayerGroup(
     selected: { [key: string]: ISelection },

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -409,11 +409,7 @@ export class JupyterGISModel implements IJupyterGISModel {
     }
   }
 
-  moveItemsToGroup(
-    items: string[],
-    groupName: string,
-    index?: number
-  ) {
+  moveItemsToGroup(items: string[], groupName: string, index?: number) {
     const layerTree = this.getLayerTree();
     for (const item of items) {
       if (this.getLayer(item)) {
@@ -426,7 +422,7 @@ export class JupyterGISModel implements IJupyterGISModel {
         if (treeInfo === undefined) {
           continue;
         }
-        const group = {...treeInfo.workingGroup};
+        const group = { ...treeInfo.workingGroup };
         this._removeLayerTreeGroup(layerTree, item);
         this._addLayerTreeItem(group, groupName, index);
       }
@@ -444,7 +440,7 @@ export class JupyterGISModel implements IJupyterGISModel {
       if (treeInfo === undefined) {
         return;
       }
-      insertedItem = {...treeInfo.workingGroup};
+      insertedItem = { ...treeInfo.workingGroup };
       this._removeLayerTreeGroup(layerTree, item);
     }
     const indexesPath = Private.findItemPath(layerTree, relativeItem);
@@ -700,11 +696,7 @@ namespace Private {
         if (item.name === itemId) {
           return workingIndexes;
         }
-        const foundIndexes = findItemPath(
-          item.layers,
-          itemId,
-          workingIndexes
-        );
+        const foundIndexes = findItemPath(item.layers, itemId, workingIndexes);
         if (foundIndexes.length > workingIndexes.length) {
           return foundIndexes;
         }

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -308,7 +308,7 @@ export class JupyterGISModel implements IJupyterGISModel {
    *   from root of layer tree.
    */
   addGroup(name: string, groupName?: string, position?: number): void {
-    const indexesPath = Private.findGroupPath(this.getLayerTree(), name);
+    const indexesPath = Private.findItemPath(this.getLayerTree(), name);
     if (indexesPath.length) {
       console.warn(`The group "${groupName}" already exist in the layer tree`);
       return;
@@ -409,18 +409,60 @@ export class JupyterGISModel implements IJupyterGISModel {
     }
   }
 
-  moveSelectedLayersToGroup(
-    selected: { [key: string]: ISelection },
-    groupName: string
+  moveItemsToGroup(
+    items: string[],
+    groupName: string,
+    index?: number
   ) {
     const layerTree = this.getLayerTree();
-    for (const item in selected) {
-      this._removeLayerTreeLayer(layerTree, item);
+    for (const item of items) {
+      if (this.getLayer(item)) {
+        // the item is a layer, remove and add it at the correct position.
+        this._removeLayerTreeLayer(layerTree, item);
+        this._addLayerTreeItem(item, groupName, index);
+      } else {
+        // the item is a group, let's copy it before removing it.
+        const treeInfo = this._getLayerTreeInfo(item);
+        if (treeInfo === undefined) {
+          continue;
+        }
+        const group = {...treeInfo.workingGroup};
+        this._removeLayerTreeGroup(layerTree, item);
+        this._addLayerTreeItem(group, groupName, index);
+      }
     }
+  }
 
-    for (const item in selected) {
-      this._addLayerTreeItem(item, groupName);
+  moveItemRelatedTo(item: string, relativeItem: string, after: boolean) {
+    const layerTree = this.getLayerTree();
+    let insertedItem: string | IJGISLayerGroup;
+    if (this.getLayer(item)) {
+      this._removeLayerTreeLayer(layerTree, item);
+      insertedItem = item;
+    } else {
+      const treeInfo = this._getLayerTreeInfo(item);
+      if (treeInfo === undefined) {
+        return;
+      }
+      insertedItem = {...treeInfo.workingGroup};
+      this._removeLayerTreeGroup(layerTree, item);
     }
+    const indexesPath = Private.findItemPath(layerTree, relativeItem);
+    const insertedIndex = (indexesPath.pop() ?? 0) + (after ? 1 : 0);
+    let parentGroupName = '';
+    let workingGroupId = indexesPath.shift();
+    if (workingGroupId !== undefined) {
+      let workingGroup = layerTree[workingGroupId] as IJGISLayerGroup;
+      while (indexesPath.length) {
+        workingGroupId = indexesPath.shift();
+        if (workingGroupId === undefined) {
+          break;
+        }
+        workingGroup = workingGroup.layers[workingGroupId] as IJGISLayerGroup;
+      }
+      parentGroupName = workingGroup.name;
+    }
+    this._addLayerTreeItem(insertedItem, parentGroupName, insertedIndex);
   }
 
   addNewLayerGroup(
@@ -436,7 +478,7 @@ export class JupyterGISModel implements IJupyterGISModel {
   }
 
   private _removeLayerTreeLayer(
-    layerTree: IJGISLayerTree,
+    layerTree: IJGISLayerItem[],
     layerIdToRemove: string
   ) {
     // Iterate over each item in the layerTree
@@ -452,6 +494,29 @@ export class JupyterGISModel implements IJupyterGISModel {
       } else if (typeof currentItem !== 'string' && 'layers' in currentItem) {
         // If the current item is a group, recursively call the function on its layers
         this._removeLayerTreeLayer(currentItem.layers, layerIdToRemove);
+      }
+    }
+
+    this.sharedModel.layerTree = layerTree;
+  }
+
+  private _removeLayerTreeGroup(
+    layerTree: IJGISLayerItem[],
+    groupName: string
+  ) {
+    // Iterate over each item in the layerTree
+    for (let i = 0; i < layerTree.length; i++) {
+      const currentItem = layerTree[i];
+
+      // Check if the current item is a string and matches the target
+      if (typeof currentItem !== 'string' && currentItem.name === groupName) {
+        // Remove the item from the array
+        layerTree.splice(i, 1);
+        // Decrement i to ensure the next iteration processes the remaining items correctly
+        i--;
+      } else if (typeof currentItem !== 'string' && 'layers' in currentItem) {
+        // If the current item is a group, recursively call the function on its layers
+        this._removeLayerTreeGroup(currentItem.layers, groupName);
       }
     }
 
@@ -511,7 +576,7 @@ export class JupyterGISModel implements IJupyterGISModel {
       }
     | undefined {
     const layerTree = this.getLayerTree();
-    const indexesPath = Private.findGroupPath(layerTree, groupName);
+    const indexesPath = Private.findItemPath(layerTree, groupName);
     if (!indexesPath.length) {
       console.warn(`The group "${groupName}" does not exist in the layer tree`);
       return;
@@ -609,30 +674,35 @@ namespace Private {
   }
 
   /**
-   * Recursive function through the layer tree to retrieve the indexes path to a group.
+   * Recursive function through the layer tree to retrieve the indexes path to a group
+   * or a layer.
    *
    * @param items - the items list being scanned.
-   * @param groupName - the target group name.
+   * @param itemId - the target group name or layer ID.
    * @param indexes - the current indexes path to the group
    */
-  export function findGroupPath(
+  export function findItemPath(
     items: IJGISLayerItem[],
-    groupName: string,
+    itemId: string,
     indexes: number[] = []
   ): number[] {
     for (let index = 0; index < items.length; index++) {
       const item = items[index];
       if (typeof item === 'string') {
-        continue;
+        if (item === itemId) {
+          const workingIndexes = [...indexes];
+          workingIndexes.push(index);
+          return workingIndexes;
+        }
       } else {
         const workingIndexes = [...indexes];
         workingIndexes.push(index);
-        if (item.name === groupName) {
+        if (item.name === itemId) {
           return workingIndexes;
         }
-        const foundIndexes = findGroupPath(
+        const foundIndexes = findItemPath(
           item.layers,
-          groupName,
+          itemId,
           workingIndexes
         );
         if (foundIndexes.length > workingIndexes.length) {

--- a/ui-tests/tests/left-panel.spec.ts
+++ b/ui-tests/tests/left-panel.spec.ts
@@ -220,7 +220,7 @@ test.describe('#layerPanel', () => {
       await page.mouse.down();
       await page.mouse.move(firstItemBox!.x + 10, firstItemBox!.y + 10);
       // We need to force hover
-      await layerItems.first().hover({ position: { x: 10, y: 10 }});
+      await layerItems.first().hover({ position: { x: 10, y: 10 } });
 
       await expect(dragIndicator).toBeVisible();
 
@@ -232,13 +232,17 @@ test.describe('#layerPanel', () => {
         firstItemBox!.y + firstItemBox!.height - 10
       );
       // We need to force hover
-      await layerItems.first().hover({ position: { x: 10, y: firstItemBox!.height - 10 }});
+      await layerItems
+        .first()
+        .hover({ position: { x: 10, y: firstItemBox!.height - 10 } });
 
       children = await layerPanel.evaluate(div => div.children);
       expect(children[1].id === dragIndicatorId);
     });
 
-    test('should move the top raster layer using drag and drop', async ({ page }) => {
+    test('should move the top raster layer using drag and drop', async ({
+      page
+    }) => {
       const layerTree = await openLayerTree(page);
       const layers = layerTree.locator('.jp-gis-layer');
       const layerGroup = layerTree.locator('.jp-gis-layerGroup');

--- a/ui-tests/tests/left-panel.spec.ts
+++ b/ui-tests/tests/left-panel.spec.ts
@@ -196,6 +196,73 @@ test.describe('#layerPanel', () => {
       const showLayerButton = layerTree.getByTitle('Show layer');
       await showLayerButton.last().click();
     });
+
+    test('drag indicator should move', async ({ page }) => {
+      const dragIndicatorId = 'jp-drag-indicator';
+      const layerTree = await openLayerTree(page);
+      const layerPanel = layerTree.locator('#jp-gis-layer-tree');
+      const layers = layerTree.locator('.jp-gis-layer');
+      const layerItems = layerTree.locator('.jp-gis-layerItem');
+      const layerGroup = layerTree.locator('.jp-gis-layerGroup');
+      const dragIndicator = layerTree.locator(`#${dragIndicatorId}`);
+
+      // Open the first level group
+      await layerGroup.last().click();
+      await page.waitForCondition(async () => (await layerGroup.count()) === 2);
+      // Open the second level group
+      await layerGroup.last().click();
+      await page.waitForCondition(async () => (await layerItems.count()) === 5);
+
+      const topLayerBox = await layers.nth(1).boundingBox();
+      const firstItemBox = await layerItems.first().boundingBox();
+
+      await page.mouse.move(topLayerBox!.x + 10, topLayerBox!.y + 10);
+      await page.mouse.down();
+      await page.mouse.move(firstItemBox!.x + 10, firstItemBox!.y + 10);
+      // We need to force hover
+      await layerItems.first().hover({ position: { x: 10, y: 10 }});
+
+      await expect(dragIndicator).toBeVisible();
+
+      let children = await layerPanel.evaluate(div => div.children);
+      expect(children[0].id === dragIndicatorId);
+
+      await page.mouse.move(
+        firstItemBox!.x + 10,
+        firstItemBox!.y + firstItemBox!.height - 10
+      );
+      // We need to force hover
+      await layerItems.first().hover({ position: { x: 10, y: firstItemBox!.height - 10 }});
+
+      children = await layerPanel.evaluate(div => div.children);
+      expect(children[1].id === dragIndicatorId);
+    });
+
+    test('should move the top raster layer using drag and drop', async ({ page }) => {
+      const layerTree = await openLayerTree(page);
+      const layers = layerTree.locator('.jp-gis-layer');
+      const layerGroup = layerTree.locator('.jp-gis-layerGroup');
+      const main = page.locator('.jGIS-Mainview');
+
+      // Open the first level group
+      await layerGroup.last().click();
+      await page.waitForCondition(async () => (await layerGroup.count()) === 2);
+
+      const topLayerBox = await layers.first().boundingBox();
+      const lowLayerBox = await layers.last().boundingBox();
+      await page.mouse.move(topLayerBox!.x + 10, topLayerBox!.y + 10);
+      await page.mouse.down();
+      await page.mouse.move(
+        lowLayerBox!.x + 10,
+        lowLayerBox!.y + lowLayerBox!.height + 10
+      );
+      await page.mouse.up();
+
+      expect(await main.screenshot()).toMatchSnapshot({
+        name: 'top-layer-hidden.png',
+        maxDiffPixelRatio: 0.01
+      });
+    });
   });
 });
 


### PR DESCRIPTION
This PR allows reorganization of layers using drag and drop.

![Peek 2024-08-02 18-15](https://github.com/user-attachments/assets/e61ef2fa-e62d-48ef-89a2-8f64d09f35e1)

Possible improvements (maybe in a follow up PR):
- computation: currently, moving a layer or a group often requires to traverse several times the layer tree.
- fix the groups that seems to be closed inconsistently (see gif)