### PR TITLE
Add StateDB to save UI state

### DIFF
--- a/packages/base/src/panelview/leftpanel.tsx
+++ b/packages/base/src/panelview/leftpanel.tsx
@@ -4,6 +4,7 @@ import {
   JupyterGISDoc,
   SelectionType
 } from '@jupytergis/schema';
+import { IStateDB } from '@jupyterlab/statedb';
 import { SidePanel } from '@jupyterlab/ui-components';
 import { Message } from '@lumino/messaging';
 import { MouseEvent as ReactMouseEvent } from 'react';
@@ -20,6 +21,10 @@ export interface ILeftPanelOptions {
   onSelect: ({ type, item, nodeId }: ILeftPanelClickHandlerParams) => void;
 }
 
+export interface ILayerPanelOptions extends ILeftPanelOptions {
+  state: IStateDB;
+}
+
 export interface ILeftPanelClickHandlerParams {
   type: SelectionType;
   item: string;
@@ -32,6 +37,8 @@ export class LeftPanelWidget extends SidePanel {
     super();
     this.addClass('jGIS-sidepanel-widget');
     this._model = options.model;
+    this._state = options.state;
+
     const header = new ControlPanelHeader();
     this.header.addWidget(header);
 
@@ -45,6 +52,7 @@ export class LeftPanelWidget extends SidePanel {
 
     const layerTree = new LayersPanel({
       model: this._model,
+      state: this._state,
       onSelect: this._onSelect
     });
     layerTree.title.caption = 'Layer tree';
@@ -176,12 +184,14 @@ export class LeftPanelWidget extends SidePanel {
 
   private _lastSelectedNodeId: string;
   private _model: IControlPanelModel;
+  private _state: IStateDB;
 }
 
 export namespace LeftPanelWidget {
   export interface IOptions {
     model: IControlPanelModel;
     tracker: IJupyterGISTracker;
+    state: IStateDB;
   }
 
   export interface IProps {

--- a/python/jupytergis_lab/src/index.ts
+++ b/python/jupytergis_lab/src/index.ts
@@ -23,8 +23,8 @@ import {
 } from '@jupyterlab/application';
 import { WidgetTracker } from '@jupyterlab/apputils';
 import { IMainMenu } from '@jupyterlab/mainmenu';
+import { IStateDB } from '@jupyterlab/statedb';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
-
 import { ContextMenu, Menu } from '@lumino/widgets';
 import { notebookRenderePlugin } from './notebookrenderer';
 
@@ -260,19 +260,22 @@ const controlPanel: JupyterFrontEndPlugin<void> = {
   requires: [
     ILayoutRestorer,
     IJupyterGISDocTracker,
-    IJGISFormSchemaRegistryToken
+    IJGISFormSchemaRegistryToken,
+    IStateDB
   ],
   activate: (
     app: JupyterFrontEnd,
     restorer: ILayoutRestorer,
     tracker: IJupyterGISTracker,
-    formSchemaRegistry: IJGISFormSchemaRegistry
+    formSchemaRegistry: IJGISFormSchemaRegistry,
+    state: IStateDB
   ) => {
     const controlModel = new ControlPanelModel({ tracker });
 
     const leftControlPanel = new LeftPanelWidget({
       model: controlModel,
-      tracker
+      tracker,
+      state
     });
     leftControlPanel.id = 'jupytergis::leftControlPanel';
     leftControlPanel.title.caption = 'JupyterGIS Control Panel';


### PR DESCRIPTION
Add StateDB to track UI state. This only tracks if groups are expanded for now. 
#95


![state](https://github.com/user-attachments/assets/e9153c93-2d6e-466f-9938-713da25661cb)
